### PR TITLE
fix for latest Closure Compiler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject asset-minifier "0.1.4"
+(defproject asset-minifier "0.1.5-SNAPSHOT"
   :description "a library to minify CSS and Js sources"
   :url "https://github.com/yogthos/asset-minifier"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.7" :exclusions [rhino/js]]
-                 [com.google.javascript/closure-compiler "v20131014"]
+                 [com.google.javascript/closure-compiler "v20141120"]
                  [commons-io "2.4"]])

--- a/src/asset_minifier/core.clj
+++ b/src/asset_minifier/core.clj
@@ -10,7 +10,7 @@
            [com.google.javascript.jscomp
             CompilationLevel
             CompilerOptions
-            JSSourceFile]))
+            SourceFile]))
 
 (defn- delete-target [target]
   (let [f (file target)]
@@ -80,8 +80,8 @@
                      (set-optimization optimization))]
 
     (.compile compiler
-      (map #(JSSourceFile/fromFile %) externs)
-      (map #(JSSourceFile/fromFile %) assets)
+      (map #(SourceFile/fromFile %) externs)
+      (map #(SourceFile/fromFile %) assets)
       options)
     {:warnings (map #(.toString %) (.getWarnings compiler))
      :errors   (map #(.toString %) (.getErrors compiler))}))


### PR DESCRIPTION
The JSSourceFile class from the closure compiler was renamed, asset minification with v20141120 fails with
java.lang.ClassNotFoundException: com.google.javascript.jscomp.JSSourceFile

this commit updates the closure compiler dependency, bumps the version to
0.1.5-SNAPSHOT, and renames s/JSSourceFile/SourceFile/g

See https://github.com/clojure/clojurescript/commit/a4f7a89a887c483722f6ec6d75e0e7c76c7d92b2 for the same issue being fixed in Clojurescript
