### PR TITLE
update project ver, clj ver, closure ver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject asset-minifier "0.1.7"
+(defproject asset-minifier "0.1.8-SNAPSHOT"
   :description "a library to minify CSS and Js sources"
   :url "https://github.com/yogthos/asset-minifier"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.7" :exclusions [rhino/js]]
-                 [com.google.javascript/closure-compiler "v20141120"]
+                 [com.google.javascript/closure-compiler "v20160208"]
                  [commons-io "2.4"]]
   :profiles {:dev {:dependencies [[pjstadig/humane-test-output "0.6.0"]]
                    :injections [(require 'pjstadig.humane-test-output)

--- a/src/asset_minifier/core.clj
+++ b/src/asset_minifier/core.clj
@@ -7,6 +7,7 @@
            java.io.File
            org.apache.commons.io.IOUtils
            java.util.logging.Level
+           java.nio.charset.Charset
            [com.google.javascript.jscomp
             CompilationLevel
             CompilerOptions
@@ -82,7 +83,7 @@
                                              (name)
                                              (.toUpperCase)
                                              (CompilerOptions$LanguageMode/fromString))))
-                     (doto (.setOutputCharset "UTF-8"))
+                     (doto (.setOutputCharset (Charset/forName "UTF-8")))
                      (set-optimization optimization))]
 
     (.compile compiler


### PR DESCRIPTION
I want to add support for source-map generation so I started by updating clojure version and updating closure compiler version first.

0. update project version to 0.1.8-SNAPSHOT
1. update clojure version to 1.8.0
3. update closure compiler to v20160208
4. fix api compatibility.
   compiler UTF-8 charset option constructed
   using java.nio.charset.Charset