### PR TITLE
Add HTML minification #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The minifier provides three functions called `minify-html`, `minify-css` and `mi
 
 ```clojure
 (ns my.ns
-  (:require [asset-minifier.core :refer [minify-html minify-css minfy-js]]))
+  (:require [asset-minifier.core :refer [minify-html minify-css minfy-js minify]]))
 ```
 
 The `minify-html` function allows specifying config for htmlcompressor. Please refer too [clj-html-compressor](https://github.com/Atsman/clj-html-compressor).
@@ -61,6 +61,16 @@ The `:externs` key can be used to specify the externs file to be used with the a
 ```
 
 The function returns a map containing `:original-size`, `:compressed-size`, and `:gzipped-size` keys indicating the size of the assets before and after compression. In addition the map may contain `:warnings` and `:errors` keys to indicate any warnings or errors that were issued during compilation.
+
+### Minify
+
+The `minify` function can be used intead of functions describet below. It tales vector based config as argument. See example:
+
+```clojure
+(minify [[:html {:source "dev/resource/html" :target "dev/minified/html"}]
+         [:css {:source "dev/resources/css" :target "dev/minified/css/styles.min.css"}]
+         [:js {:source ["dev/res/js1", "dev/res/js2"] :target "dev/minified/js/script.min.js"}]])
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Continuous Integration status](https://secure.travis-ci.org/yogthos/asset-minifier.png)](http://travis-ci.org/yogthos/asset-minifier)
 
-A Clojure library to minify CSS and Js resources, for a Leiningen plugin see [lein-asset-minifier](https://github.com/yogthos/lein-asset-minifier).
+A Clojure library to minify HTML, CSS and Js resources, for a Leiningen plugin see [lein-asset-minifier](https://github.com/yogthos/lein-asset-minifier).
 
 The latest version requires ClojureScript 1.9+. If you're on an older version of ClojureScript, then use version `0.2.0` instead.
 
@@ -10,11 +10,18 @@ The latest version requires ClojureScript 1.9+. If you're on an older version of
 
 [![Clojars Project](http://clojars.org/asset-minifier/latest-version.svg)](http://clojars.org/asset-minifier)
 
-The minifier provides two functions called `minify-css` and `minify-js`, both functions accept a source path followed by the output target and an optional parameter map. The source can be a filename, a directory, or a sequence of directories and or filenames.
+The minifier provides three functions called `minify-html`, `minify-css` and `minify-js`, all functions accept a source path followed by the output target and an optional parameter map. The source can be a filename, a directory, or a sequence of directories and or filenames.
 
 ```clojure
 (ns my.ns
-  (:require [asset-minifier.core :refer [minify-css minfy-js]]))
+  (:require [asset-minifier.core :refer [minify-html minify-css minfy-js]]))
+```
+
+The `minify-html` function allows specifying config for htmlcompressor. Please refer too [clj-html-compressor](https://github.com/Atsman/clj-html-compressor).
+
+```clojure
+; minify html files from folder /html into /minified
+(minify-html "html" "minified")
 ```
 
 The `minify-css` function allows specifying `:linebreak` to force line breaks after a certain number of chracters in the minified CSS.
@@ -31,7 +38,6 @@ The `minify-css` function allows specifying `:linebreak` to force line breaks af
 ;minify all css resources into site.min.css
 (minify-css "dev/resources/css" "resources/public/css/site.min.css")
 ```
-
 The function returns a map containing `:original-size`, `:compressed-size`, and `:gzipped-size` keys indicating the size of the assets before and after compression.
 
 
@@ -56,10 +62,9 @@ The `:externs` key can be used to specify the externs file to be used with the a
 
 The function returns a map containing `:original-size`, `:compressed-size`, and `:gzipped-size` keys indicating the size of the assets before and after compression. In addition the map may contain `:warnings` and `:errors` keys to indicate any warnings or errors that were issued during compilation.
 
-
 ## License
 
-Copyright © 2014 Yogthos
+Copyright © 2017 Yogthos
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,11 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clojure-future-spec "1.9.0-alpha17"]
+                 [org.clojure/test.check "0.9.0"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.8" :exclusions [rhino/js]]
                  [com.google.javascript/closure-compiler "v20160208"]
-                 [clj-html-compressor "0.0.1"]
+                 [clj-html-compressor "0.1.1"]
                  [commons-io "2.5"]]
   :profiles {:dev {:dependencies [[pjstadig/humane-test-output "0.8.1"]]
                    :injections [(require 'pjstadig.humane-test-output)

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.yahoo.platform.yui/yuicompressor "2.4.8" :exclusions [rhino/js]]
                  [com.google.javascript/closure-compiler "v20160208"]
+                 [clj-html-compressor "0.0.1"]
                  [commons-io "2.5"]]
   :profiles {:dev {:dependencies [[pjstadig/humane-test-output "0.8.1"]]
                    :injections [(require 'pjstadig.humane-test-output)

--- a/src/asset_minifier/core.clj
+++ b/src/asset_minifier/core.clj
@@ -158,11 +158,11 @@
         (spit target (.toSource compiler))
         (merge result (compression-details assets (file target)))))))
 
-(defn minify-html-asset [asset target opts]
+(defn- minify-html-asset [asset target opts]
   (let [result (html-comressor/compress (slurp asset))
-        target-filename (str target (.getName asset))]
-    (make-parents target-filename)
-    (spit target-filename result)))
+        target-file (file target (.getName asset))]
+    (make-parents (.getPath target-file))
+    (spit target-file result)))
 
 (defn minify-html [path target opts]
   (delete-target target)

--- a/src/asset_minifier/core.clj
+++ b/src/asset_minifier/core.clj
@@ -30,9 +30,9 @@
 (defn- aggregate [path ext]
   (if (coll? path)
     (flatten
-      (for [item path]
-        (let [f (file item)]
-          (find-assets f ext))))
+     (for [item path]
+       (let [f (file item)]
+         (find-assets f ext))))
     (let [f (file path)]
       (find-assets f ext))))
 

--- a/src/asset_minifier/core.clj
+++ b/src/asset_minifier/core.clj
@@ -1,7 +1,8 @@
 (ns asset-minifier.core
   (:require [clojure.java.io :refer [file reader writer make-parents]]
             [clojure.string :as string]
-            [clj-html-compressor.core :as html-comressor])
+            [clj-html-compressor.core :as html-comressor]
+            [asset-minifier.spec :as spec])
   (:import com.yahoo.platform.yui.compressor.CssCompressor
            java.util.zip.GZIPOutputStream
            java.io.FileInputStream
@@ -172,9 +173,11 @@
       (minify-html-asset asset target opts))
     (compression-details assets (aggregate target html))))
 
-(def asset-type-minifier {:html minify-html
-                          :css minify-css
-                          :js minify-js})
+(defn get-minifier-fn-by-type [asset-type]
+  (case asset-type
+    :html minify-html
+    :css minify-css
+    :js minify-js))
 
 (defn minify 
   "assers are specified using a vector of configs
@@ -182,7 +185,7 @@
    [:css {:source \"dev/resources/css\" :target \"dev/minified/css/styles.min.css\"}]
    [:js {:source [\"dev/res/js1\", \"dev/res/js2\"] :target \"dev/minified/js/script.min.js\"}]]"
   [config]
+  {:pre [(spec/is-valid-config config)]}
   (doseq [[asset-type opts] config]
-    (println asset-type opts)
-    (let [minify-fn (get asset-type-minifier asset-type)]
+    (let [minify-fn (get-minifier-fn-by-type asset-type)]
       (minify-fn (:source opts) (:target opts) (:opts opts)))))

--- a/src/asset_minifier/spec.clj
+++ b/src/asset_minifier/spec.clj
@@ -1,9 +1,10 @@
 (ns asset-minifier.spec
   (:require [clojure.spec.alpha :as s]))
 
-(s/def ::path (s/or :path string?
-                    :paths (s/+ string?)))
-(s/def ::source ::path)
+(s/def ::path (s/or :path string?))
+(s/def ::paths (s/coll-of ::path))
+(s/def ::source (s/or :path ::path
+                      :paths ::paths))
 (s/def ::target ::path)
 (s/def ::opts map?)
 (s/def ::config-body (s/keys :req-un [::source ::target]

--- a/src/asset_minifier/spec.clj
+++ b/src/asset_minifier/spec.clj
@@ -1,0 +1,19 @@
+(ns asset-minifier.spec
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::path (s/or :path string?
+                    :paths (s/+ string?)))
+(s/def ::source ::path)
+(s/def ::target ::path)
+(s/def ::opts map?)
+(s/def ::config-body (s/keys :req-un [::source ::target]
+                             :opt-un [::opts]))
+(s/def ::asset-type #{:html :css :js})
+(s/def ::config-item (s/cat :asset-type ::asset-type :config-body ::config-body))
+(s/def ::config (s/coll-of ::config-item))
+
+(defn is-valid-config [config]
+  (s/valid? ::config config))
+
+(defn explain-config [config]
+  (s/explain ::config config))

--- a/test/asset_minifier/core_test.clj
+++ b/test/asset_minifier/core_test.clj
@@ -118,4 +118,9 @@
       :compressed-size 1265,
       :gzipped-size 600
       :warnings
-      ["JSC_UNDEFINED_EXTERN_VAR_ERROR. name hljs is not defined in the externs. at test/resources/js/externs.js line 1 : 0"]})))
+      ["JSC_UNDEFINED_EXTERN_VAR_ERROR. name hljs is not defined in the externs. at test/resources/js/externs.js line 1 : 0"]}))
+
+  (testing "html minification"
+    (run-test
+     (minify-html (str input-path "/html/") (str output-path "html/") {})
+     {:sources '("testCompress.html") :targets '("testCompress.html") :original-size 581 :compressed-size 459 :gzipped-size 256})))

--- a/test/asset_minifier/core_test.clj
+++ b/test/asset_minifier/core_test.clj
@@ -14,8 +14,8 @@
 
 (defn massage-data [m]
   (-> m
-   (update-in [:sources] set)
-   (update-in [:gzipped-size] #(when % (int (/ % 100))))))
+      (update-in [:sources] set)
+      (update-in [:gzipped-size] #(when % (int (/ % 100))))))
 
 (defmacro run-test [fn result]
   `(do
@@ -28,94 +28,94 @@
 
     ;; minify directory
     (run-test
-      (minify-css input-path (str output-path "output.min.css"))
-      {:sources '("input1.css" "input2.css")
-       :target "output.min.css"
-       :original-size 3883
-       :compressed-size 3069
-       :gzipped-size 1022})
+     (minify-css input-path (str output-path "output.min.css"))
+     {:sources '("input1.css" "input2.css")
+      :target "output.min.css"
+      :original-size 3883
+      :compressed-size 3069
+      :gzipped-size 1022})
 
     ;; minify a file
     (run-test
-      (minify-css (str input-path "/css/input1.css") (str output-path "output.min.css"))
-      {:sources '("input1.css"),
-       :target "output.min.css",
-       :original-size 989,
-       :compressed-size 784,
-       :gzipped-size 423})
+     (minify-css (str input-path "/css/input1.css") (str output-path "output.min.css"))
+     {:sources '("input1.css"),
+      :target "output.min.css",
+      :original-size 989,
+      :compressed-size 784,
+      :gzipped-size 423})
 
     ;; minify a file into non-existent directory
     (run-test
-      (minify-css (str input-path "/css/input1.css") (str output-path "missing-css-dir/output.min.css"))
-      {:sources '("input1.css"),
-       :target "output.min.css",
-       :original-size 989,
-       :compressed-size 784,
-       :gzipped-size 423})
+     (minify-css (str input-path "/css/input1.css") (str output-path "missing-css-dir/output.min.css"))
+     {:sources '("input1.css"),
+      :target "output.min.css",
+      :original-size 989,
+      :compressed-size 784,
+      :gzipped-size 423})
     (is (= true (.exists (file (str output-path "missing-css-dir/output.min.css")))))
 
     ;; minify a file with custom linebreak
     (run-test
-      (minify-css (str input-path "/css/input2.css") (str output-path "output.min.css") {:linebreak 80})
-      {:sources '("input2.css"),
-       :target "output.min.css",
-       :original-size 2894,
-       :compressed-size 2301,
-       :gzipped-size 725}))
+     (minify-css (str input-path "/css/input2.css") (str output-path "output.min.css") {:linebreak 80})
+     {:sources '("input2.css"),
+      :target "output.min.css",
+      :original-size 2894,
+      :compressed-size 2301,
+      :gzipped-size 725}))
 
   (testing "testing Js minifcation"
 
     ;; minify directory
     (run-test
-      (minify-js input-path (str output-path "output.min.js"))
-      {:warnings ()
-       :errors ()
-       :sources ["externs.js" "input1.js" "input2.js"]
-       :target "output.min.js"
-       :original-size 2547
-       :compressed-size 1804
-       :gzipped-size 807})
+     (minify-js input-path (str output-path "output.min.js"))
+     {:warnings ()
+      :errors ()
+      :sources ["externs.js" "input1.js" "input2.js"]
+      :target "output.min.js"
+      :original-size 2547
+      :compressed-size 1804
+      :gzipped-size 807})
 
     ;; minify a file
     (run-test
-      (minify-js (str input-path "/js/input1.js") (str output-path "output.min.js"))
-      {:warnings ()
-       :errors ()
-       :sources ["input1.js"]
-       :target "output.min.js"
-       :original-size 117
-       :compressed-size 84
-       :gzipped-size 93})
+     (minify-js (str input-path "/js/input1.js") (str output-path "output.min.js"))
+     {:warnings ()
+      :errors ()
+      :sources ["input1.js"]
+      :target "output.min.js"
+      :original-size 117
+      :compressed-size 84
+      :gzipped-size 93})
 
     ;; minify a file into non-existent directory
     (run-test
-      (minify-js (str input-path "/js/input1.js") (str output-path "missing-js-dir/output.min.js"))
-      {:warnings ()
-       :errors ()
-       :sources ["input1.js"]
-       :target "output.min.js"
-       :original-size 117
-       :compressed-size 84
-       :gzipped-size 93})
+     (minify-js (str input-path "/js/input1.js") (str output-path "missing-js-dir/output.min.js"))
+     {:warnings ()
+      :errors ()
+      :sources ["input1.js"]
+      :target "output.min.js"
+      :original-size 117
+      :compressed-size 84
+      :gzipped-size 93})
     (is (= true (.exists (file (str output-path "missing-js-dir/output.min.js")))))
 
     ;; minify a file without optimization
     (run-test
-      (minify-js (str input-path "/js/input1.js") (str output-path "output.min.js")
-        {:optimization :none})
-      {:sources ["input1.js"]
-       :target "output.min.js"
-       :original-size 117})
+     (minify-js (str input-path "/js/input1.js") (str output-path "output.min.js")
+                {:optimization :none})
+     {:sources ["input1.js"]
+      :target "output.min.js"
+      :original-size 117})
 
     ;; minify a file with advanced optimization
     (run-test
-      (minify-js (str input-path "/js/input2.js") (str output-path "output.min.js")
-        {:optimization :advanced :externs [(str input-path "/js/externs.js")]})
-        {:errors (),
-         :sources #{"input2.js"},
-         :target "output.min.js",
-         :original-size 2409,
-         :compressed-size 1265,
-         :gzipped-size 600
-         :warnings
-         ["JSC_UNDEFINED_EXTERN_VAR_ERROR. name hljs is not defined in the externs. at test/resources/js/externs.js line 1 : 0"]})))
+     (minify-js (str input-path "/js/input2.js") (str output-path "output.min.js")
+                {:optimization :advanced :externs [(str input-path "/js/externs.js")]})
+     {:errors (),
+      :sources #{"input2.js"},
+      :target "output.min.js",
+      :original-size 2409,
+      :compressed-size 1265,
+      :gzipped-size 600
+      :warnings
+      ["JSC_UNDEFINED_EXTERN_VAR_ERROR. name hljs is not defined in the externs. at test/resources/js/externs.js line 1 : 0"]})))

--- a/test/asset_minifier/spec_test.clj
+++ b/test/asset_minifier/spec_test.clj
@@ -6,12 +6,21 @@
 (deftest spec-test
   (testing "path spec"
     (is (s/valid? ::spec/path "path"))
-    (is (s/valid? ::spec/path ["vector" "of" "paths"]))
-    (is (not (s/valid? ::spec/path :some-thing-else))))
+    (is (s/valid? ::spec/paths ["vector" "of" "paths"]))
+    (is (not (s/valid? ::spec/path :something-else))))
+
+  (testing "source test"
+    (is (s/valid? ::spec/source "source"))
+    (is (s/valid? ::spec/source ["source"]))
+    (is (not (s/valid? ::spec/source :something-else))))
+
+  (testing "target test"
+    (is (s/valid? ::spec/target "target"))
+    (is (not (s/valid? ::spec/target ["vector" "of" "targets"]))))
   
   (testing "config body"
     (is (s/valid? ::spec/config-body {:source "str" :target "str"}))
-    (is (s/valid? ::spec/config-body {:source ["str"] :target ["str"]}))
+    (is (s/valid? ::spec/config-body {:source ["str"] :target "str"}))
     (is (not (s/valid? ::spec/config-body {:source "source"})))
     (is (not (s/valid? ::spec/config-body {:target "target"}))))
   
@@ -19,13 +28,13 @@
     (is (s/valid? ::spec/asset-type :html))
     (is (s/valid? ::spec/asset-type :css))
     (is (s/valid? ::spec/asset-type :js))
-    (is (not (s/valid? ::spec/asset-type :not-known))))
+    (is (not (s/valid? ::spec/asset-type :something-else))))
   
   (testing "is-valid-config"
     (is (spec/is-valid-config [[:html {:source "str" :target "str"}]]))
     (is (spec/is-valid-config [[:html {:source "str" :target "str"}]
                                [:css {:source ["str1" "str2"] :target "str"}]
-                               [:js {:source "str" :target ["str1" "str2"]}]]))
+                               [:js {:source "str" :target "str2"}]]))
     (is (not (spec/is-valid-config [[]])))
     (is (not (spec/is-valid-config [[:html {}]])))))
 

--- a/test/asset_minifier/spec_test.clj
+++ b/test/asset_minifier/spec_test.clj
@@ -1,0 +1,31 @@
+(ns asset-minifier.spec-test
+  (:require [clojure.test :refer :all]
+            [clojure.spec.alpha :as s]
+            [asset-minifier.spec :as spec]))
+
+(deftest spec-test
+  (testing "path spec"
+    (is (s/valid? ::spec/path "path"))
+    (is (s/valid? ::spec/path ["vector" "of" "paths"]))
+    (is (not (s/valid? ::spec/path :some-thing-else))))
+  
+  (testing "config body"
+    (is (s/valid? ::spec/config-body {:source "str" :target "str"}))
+    (is (s/valid? ::spec/config-body {:source ["str"] :target ["str"]}))
+    (is (not (s/valid? ::spec/config-body {:source "source"})))
+    (is (not (s/valid? ::spec/config-body {:target "target"}))))
+  
+  (testing "asset type"
+    (is (s/valid? ::spec/asset-type :html))
+    (is (s/valid? ::spec/asset-type :css))
+    (is (s/valid? ::spec/asset-type :js))
+    (is (not (s/valid? ::spec/asset-type :not-known))))
+  
+  (testing "is-valid-config"
+    (is (spec/is-valid-config [[:html {:source "str" :target "str"}]]))
+    (is (spec/is-valid-config [[:html {:source "str" :target "str"}]
+                               [:css {:source ["str1" "str2"] :target "str"}]
+                               [:js {:source "str" :target ["str1" "str2"]}]]))
+    (is (not (spec/is-valid-config [[]])))
+    (is (not (spec/is-valid-config [[:html {}]])))))
+

--- a/test/resources/html/testCompress.html
+++ b/test/resources/html/testCompress.html
@@ -1,0 +1,10 @@
+<a x="aaa 'bbb' ccc"  b="1">   <b   onclick  =  "  alert('<a>   <b>')  "  /> <c/>   
+   <d />
+<pre    a   =   "  1  ">    <x   />    <y>   </pre>
+<!-- comment -->
+<!--[if lt IE 7 ]>        <body class="ie6">      <![endif]-->           <!--[if lt IE 7 ]>        <body class="ie6">      <![endif]-->
+<pre>          <!-- comment -->     </pre>
+<textarea>          <!-- comment -->     </textarea>
+<script>          <!-- comment -->     </script>
+<script type="text/x-jquery-tmpl">     <a>     <!-- comment -->   <b>   </script>
+<style>          <!-- comment -->     </style>


### PR DESCRIPTION
Hi @yogthos,

Please review my changes. Most important loot at minify multimethods. I added new multimethod for vector based config like:

```clojure
[[:html {:source "dev/resources/html" :target "dev/resources/min/html"}]
 [:css {:source ["dev/resources/css", "dev/resources/css1"] :target "dev/resources/styles.min.css"}]
 [:js {:source "dev/resources/js" :target "dev/resources/scripts.min.js"}]]
```

And it is possible to configure staff with old variant. I am not sure, should we leave it or not. If we going to release new major version - we can remove old style configuration.

If everything is fine - i will update readme and documentation.

Anyway i am looking for your review and feedback.
Aleh