### PR TITLE
BREAKING: Handle language-out option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The `minify-js` function allows specifying the level of optimizations, which can
 
 The `:externs` key can be used to specify the externs file to be used with the advanced optimisations to prevent munging of external functions.
 
+The default input language is ecmascript6 with an ecmascript5 output. This can be changed with setting the `:language-out` key to `:ecmascript3` for example. The es6 output is not supported by the closure-compiler currently included.
+
 ```clojure
 ;minify site.js into site.min.js
 (minify-js "site.js" "site.min.js")
@@ -54,7 +56,8 @@ The `:externs` key can be used to specify the externs file to be used with the a
 
 ;minify site.js into site.min.js with advanced optimizations and jquery externs
 (minify-js "site.js" "site.min.js" {:optimization :advanced
-                                    :externs ["jquery.min.js"]})
+                                    :externs ["jquery.min.js"]
+                                    :language-out :ecmascript3})
 
 ;minify all Js resources into site.min.js
 (minify-js "dev/resources/js" "resources/public/js/site.min.js")

--- a/src/asset_minifier/core.clj
+++ b/src/asset_minifier/core.clj
@@ -169,7 +169,7 @@
 
 (defn minify-js [path target & [{:keys [quiet? externs optimization language-in language-out]
                                  :or {quiet? false
-                                      language-in :ecmascript5
+                                      language-in :ecmascript6
                                       language-out :ecmascript5
                                       externs []
                                       optimization :simple}}]]

--- a/src/asset_minifier/core.clj
+++ b/src/asset_minifier/core.clj
@@ -161,9 +161,10 @@
    :target (.getName (file target))
    :original-size (total-size sources)})
 
-(defn minify-js [path target & [{:keys [quiet? externs optimization language]
+(defn minify-js [path target & [{:keys [quiet? externs optimization language language-out]
                                  :or {quiet? false
                                       language :ecmascript5
+                                      language-out :ecmascript5
                                       externs []
                                       optimization :simple}}]]
   (delete-target target)
@@ -175,7 +176,7 @@
         (com.google.javascript.jscomp.Compiler/setLoggingLevel Level/SEVERE))
       (let [assets   (aggregate path js)
             compiler (com.google.javascript.jscomp.Compiler.)
-            result   (compile-js compiler assets externs optimization language)]
+            result   (compile-js compiler assets externs optimization language language-out)]
         (spit target (.toSource compiler))
         (merge result (compression-details assets (file target)))))))
 

--- a/test/asset_minifier/core_test.clj
+++ b/test/asset_minifier/core_test.clj
@@ -67,9 +67,7 @@
 
     ;; minify directory
     (run-test
-     (minify-js input-path (str output-path "output.min.js")
-                {:language-in :ecmascript6
-                 :language-out :ecmascript5})
+     (minify-js input-path (str output-path "output.min.js"))
      {:warnings ()
       :errors ()
       :sources ["externs.js" "input1.js" "input2.js", "input3.js"]

--- a/test/asset_minifier/core_test.clj
+++ b/test/asset_minifier/core_test.clj
@@ -67,13 +67,15 @@
 
     ;; minify directory
     (run-test
-     (minify-js input-path (str output-path "output.min.js"))
+     (minify-js input-path (str output-path "output.min.js")
+                {:language-in :ecmascript6
+                 :language-out :ecmascript5})
      {:warnings ()
       :errors ()
-      :sources ["externs.js" "input1.js" "input2.js"]
+      :sources ["externs.js" "input1.js" "input2.js", "input3.js"]
       :target "output.min.js"
-      :original-size 2547
-      :compressed-size 1804
+      :original-size 2586
+      :compressed-size 1841
       :gzipped-size 807})
 
     ;; minify a file
@@ -115,7 +117,7 @@
       :sources #{"input2.js"},
       :target "output.min.js",
       :original-size 2409,
-      :compressed-size 1265,
+      :compressed-size 1418,
       :gzipped-size 600
       :warnings
       ["JSC_UNDEFINED_EXTERN_VAR_ERROR. name hljs is not defined in the externs. at test/resources/js/externs.js line 1 : 0"]}))
@@ -125,14 +127,14 @@
      (minify-html (str input-path "/html/") (str output-path "html/") {})
      {:sources '("testCompress.html") :targets '("testCompress.html") :original-size 581 :compressed-size 459 :gzipped-size 256}))
 
-  (testing "minify function" 
+  (testing "minify function"
     (is (= (minify [[:html {:source (str input-path "/html/") :target (str output-path "html/")}]
                     [:js {:source (str input-path "/js/input1.js") :target (str output-path "output.min.js")}]
                     [:css {:source (str input-path "/css/input1.css") :target (str output-path "output.min.css")}]])
-            [{:sources '("testCompress.html") 
-              :targets '("testCompress.html") 
-              :original-size 581 
-              :compressed-size 459 
+            [{:sources '("testCompress.html")
+              :targets '("testCompress.html")
+              :original-size 581
+              :compressed-size 459
               :gzipped-size 256}
              {:warnings ()
               :errors ()

--- a/test/resources/js/input3.js
+++ b/test/resources/js/input3.js
@@ -1,0 +1,2 @@
+const foo = "bar"
+console.log({ foo })


### PR DESCRIPTION
Fixes #17 
Allows for setting of `language-out` option.

Concats externs with default externs for ES6 support.

*BREAKING* `language` renamed to `language-in` for sake of descriptiveness.

If you think, I'm also OK with leaving it as-is for the sake of backwards compatibility.